### PR TITLE
Use Express 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "browser"
   ],
   "dependencies": {
-    "express": "*",
+    "express": "3.6.0",
     "socket.io": "0.9.13",
     "grunt": "*",
     "grunt-contrib-uglify": "*",


### PR DESCRIPTION
We need to use Express 3x until we update it
Express 4x is very different, there is a few things we need to change before using it.
See https://github.com/visionmedia/express/wiki/Migrating-from-3.x-to-4.x
